### PR TITLE
Renamed the 'SD Cartridge Programs' folder

### DIFF
--- a/create_image.sh
+++ b/create_image.sh
@@ -46,10 +46,10 @@ rm -r software-main/cassettes/.support
 cp -r software-main/cassettes/* $ROOT_MOUNT
 
 # download PRG images
-mkdir $ROOT_MOUNT/99\ SD\ cartridge\ programs
-wget https://github.com/ifilot/p2000t-sdcard-cartridge-programs/releases/download/latest/CASDUMP.PRG -O $ROOT_MOUNT/99\ SD\ cartridge\ programs/CASDUMP.PRG
-wget https://github.com/ifilot/p2000t-sdcard-cartridge-programs/releases/download/latest/HELLOWORLD.PRG -O $ROOT_MOUNT/99\ SD\ cartridge\ programs/HELLOWORLD.PRG
-wget https://github.com/ifilot/p2000t-sdcard-cartridge-programs/releases/download/latest/MONCRC16.PRG -O $ROOT_MOUNT/99\ SD\ cartridge\ programs/MONCRC16.PRG
+mkdir $ROOT_MOUNT/SD\ Cartridge\ Programs
+wget https://github.com/ifilot/p2000t-sdcard-cartridge-programs/releases/download/latest/CASDUMP.PRG -O $ROOT_MOUNT/SD\ Cartridge\ Programs/CASDUMP.PRG
+wget https://github.com/ifilot/p2000t-sdcard-cartridge-programs/releases/download/latest/HELLOWORLD.PRG -O $ROOT_MOUNT/SD\ Cartridge\ Programs/HELLOWORLD.PRG
+wget https://github.com/ifilot/p2000t-sdcard-cartridge-programs/releases/download/latest/MONCRC16.PRG -O $ROOT_MOUNT/SD\ Cartridge\ Programs/MONCRC16.PRG
 
 # download latest firmwares (!0x40 variant implied!)
 wget https://github.com/ifilot/p2000t-sdcard/releases/latest/download/LAUNCHER.BIN -O $ROOT_MOUNT/LAUNCHER.BIN


### PR DESCRIPTION
Renamed the `90 SD cartridge programs` folder to `SD Cartridge Programs`.

Reasoning: A couple of days ago I renamed all the cassette folders to `01 Spelletjes`, `02 Grafische programma's`, etc., because that way I could control the default ordering. However, I didn't realize that these sort-numbers will be confusing in the Launcher, as sequence numbers are already added in front of the files/folders, which then shows as `2 01 Spelletjes`, `3 02 Grafische programma's`, etc.

So I removed these sort-numbers in the p2000t/software/cassettes folders.
This PR will also remove the sort-number for the SD Cartridge Programs folder.